### PR TITLE
ensure valid c# or java literal

### DIFF
--- a/src/common/generator.js
+++ b/src/common/generator.js
@@ -108,6 +108,13 @@ window.POG=(function() {
         return selector.replace(/^html[^\b]*\bbody\b/, '').trim();
     }
 
+    function getValidVariableName(name) {
+        if (name.length && !/[$_a-zA-Z]/.test(name[0])) {
+            return '_' + name;
+        }
+        return name;
+    }
+
     function getDefinition(input) {
         input = input || {};
         var actionLowered = input.action.toLowerCase();
@@ -138,7 +145,7 @@ window.POG=(function() {
                 input.letters.attribute);
         }
 
-        buffer.attribute.name = getLetter(input.text, input.letters.attribute);
+        buffer.attribute.name = getValidVariableName(getLetter(input.text, input.letters.attribute));
         buffer.operation.documentation = input.action + suffixes.action +
             suffixes.documentation;
         buffer.operation.name = getLetter(input.action + suffixes.name,


### PR DESCRIPTION
In some cases, like when dealing with version names, rendered template may produce invalid java or c# variable names.

```java
    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.1']")
    @CacheLookup
    private WebElement 101;

    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.2']")
    @CacheLookup
    private WebElement 102;
```
This PR is to fix this. I have prefixed the variable names with an underscore:

```java
    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.1']")
    @CacheLookup
    private WebElement _101;

    @FindBy(css = "a[href='/rickypc/selenium-page-object-generator/tree/1.0.2']")
    @CacheLookup
    private WebElement _102;
```